### PR TITLE
Fixed bug in RecognitionLongAudio.get_data

### DIFF
--- a/src/speechkit/_recognition/sync_recognition.py
+++ b/src/speechkit/_recognition/sync_recognition.py
@@ -355,7 +355,7 @@ class RecognitionLongAudio:
 
         if self._answer_data is None:
             raise ValueError("You must call `RecognitionLongAudio.get_recognition_results` first")
-        return self._answer_data.get('results')
+        return self._answer_data.get('response', {}).get('chunks', [])
 
     def get_raw_text(self):
         """


### PR DESCRIPTION
The response body (`_answer_data`) now has the following structure: https://cloud.yandex.com/en/docs/speechkit/stt/transcribation#get-result-response