### PR TITLE
Update sync recognition

### DIFF
--- a/src/speechkit/_recognition/sync_recognition.py
+++ b/src/speechkit/_recognition/sync_recognition.py
@@ -412,5 +412,7 @@ class RecognitionLongAudio:
 
         text = ''
         for chunk in self._answer_data.get('response', {}).get('chunks', []):
-            text += chunk['alternatives'][0]['text']
+            # text += chunk['alternatives'][0]['text']
+            if chunk['channelTag'] == '1':
+                text += f"{chunk['alternatives'][0]['text'].strip()} "
         return text

--- a/src/speechkit/_recognition/sync_recognition.py
+++ b/src/speechkit/_recognition/sync_recognition.py
@@ -412,7 +412,6 @@ class RecognitionLongAudio:
 
         text = ''
         for chunk in self._answer_data.get('response', {}).get('chunks', []):
-            # text += chunk['alternatives'][0]['text']
             if chunk['channelTag'] == '1':
                 text += f"{chunk['alternatives'][0]['text'].strip()} "
         return text


### PR DESCRIPTION
for 2 channel audio we have duplicates in result. for example: "сын полкасын полкапосвящается жене и павлику катаевымпосвящается жене и павлику катаевымэто многихэто". I update get_raw_text method for saving only 1 channel result.